### PR TITLE
Fix cannot load entities error

### DIFF
--- a/src/db/dataSource.ts
+++ b/src/db/dataSource.ts
@@ -1,12 +1,13 @@
 import "dotenv/config"
+import path from "path"
 import { DataSource } from "typeorm"
 
 const dataSource = new DataSource({
   type: "postgres",
   url: process.env.DB_URL,
   synchronize: false,
-  entities: [__dirname + "/entities/*.ts"],
-  migrations: [__dirname + "/migrations/*.ts"],
+  entities: [path.join(__dirname, "/entities/*{.ts,.js}")],
+  migrations: [path.join(__dirname, "/migrations/*{.ts,.js}")],
   extra: {
     max: 1,
   },


### PR DESCRIPTION
## Fix
### Typeorm datasource cannot load entities error
> #### Resolve by adding the `.js` filename extension, such as `*{.ts,.js}`
```
const dataSource = new DataSource({
  type: "postgres",
  url: process.env.DB_URL,
  synchronize: false,
  entities: [path.join(__dirname, "/entities/*{.ts,.js}")],
  migrations: [path.join(__dirname, "/migrations/*{.ts,.js}")],
  extra: {
    max: 1,
  },
})
```